### PR TITLE
Fix incorrect pt_BR plural form expression.

### DIFF
--- a/docs/l10n/pluralforms.rst
+++ b/docs/l10n/pluralforms.rst
@@ -160,7 +160,7 @@ a correct plural form
    pl,    Polish,                nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);
    pms,   Piemontese,            nplurals=2; plural=(n != 1);
    pt,    Portuguese,            nplurals=2; plural=(n != 1);
-   pt_BR, Brazilian Portuguese,  nplurals=2; plural=(n != 1);
+   pt_BR, Brazilian Portuguese,  nplurals=2; plural=(n > 1);
    **R**
    rm,    Romansh,               nplurals=2; plural=(n != 1);
    ro,    Romanian,              nplurals=3; plural=(n==1 ? 0 : (n==0 || (n%100 > 0 && n%100 < 20)) ? 1 : 2);


### PR DESCRIPTION
The expressions for Portuguese and Brazilian Portuguese were incorrectly the same, but there's a subtle difference: in `pt`, 0 is considered plural, while it is singular in `pt_BR`.

Sources: `gettext-tools/src/plural-table.c` in GNU gettext 0.18.3.1 as well as Mozilla and Launchpad language descriptions:
https://translations.launchpad.net/+languages/pt_BR
https://translations.launchpad.net/+languages/pt
(Unicode CLDR doesn't have a Brazilian variant entry)
