### PR TITLE
Update pluralforms.rst

### DIFF
--- a/docs/l10n/pluralforms.rst
+++ b/docs/l10n/pluralforms.rst
@@ -190,7 +190,7 @@ a correct plural form
    ti,    Tigrinya,              nplurals=2; plural=(n > 1);
    th,    Thai,                  nplurals=1; plural=0;
    tk,    Turkmen,               nplurals=2; plural=(n != 1);
-   tr,    Turkish,               nplurals=2; plural=(n > 1);
+   tr,    Turkish,               nplurals=1; plural=0;
    tt,    Tatar,                 nplurals=1; plural=0;
    **U**
    ug,    Uyghur,                nplurals=1; plural=0;


### PR DESCRIPTION
Mistake in Turkish plural form which is inconsistent with default Pootle settings.  Refer to https://developer.mozilla.org/en-US/docs/Mozilla/Localization/Localization_and_Plurals
