### PR TITLE
add new language me(Montenegro) to plural forms

### DIFF
--- a/docs/l10n/pluralforms.rst
+++ b/docs/l10n/pluralforms.rst
@@ -130,6 +130,7 @@ a correct plural form
    lv,    Latvian,               nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n != 0 ? 1 : 2);
    **M**
    mai,   Maithili,              nplurals=2; plural=(n != 1);
+   me,    Montenegro,            nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;
    mfe,   Mauritian Creole,      nplurals=2; plural=(n > 1);
    mg,    Malagasy,              nplurals=2; plural=(n > 1);
    mi,    Maori,                 nplurals=2; plural=(n > 1);


### PR DESCRIPTION
From a user requesting this language to be added into our translation platform. Since our plural forms are based on this page so I thought I should feed this back to this page.
