### PR TITLE
Use GitHub repo for Contributing page

### DIFF
--- a/docs/guide/contributing.rst
+++ b/docs/guide/contributing.rst
@@ -9,8 +9,9 @@ Please think of this as a living document.  If you are using part of it and
 find that it is out of date then please update it so that others don't have to
 go through your pain.
 
-If you have a new section to contribute or some corrections then please create
-an account and make changes.  If you feel it might be controvercial then please
+If you have a new section to contribute or some corrections then please go to
+our `GitHub Repository <https://github.com/translate/l10n-guide>`, make changes
+and create a pull request.  If you feel it might be controvercial then please
 email translate-devel@lists.sourceforge.net. If you have some criticism
 we also welcome it but if you accompany it with the changes then you are more
 likely to be listened to (its easy to complain, a little harder to contribute


### PR DESCRIPTION
This edit points new contributors directly to the GitHub repo here. I think there should also be a link to https://github.com/translate/l10n-guide/graphs/contributors on the credits page, but my laziness won.

And you should also add a link to https://localization-guide.rtfd.org in the URL part of the repo description. Just go to https://github.com/translate/l10n-guide, click on 'Localization Guide — **Edit**', and put the URL in the corresponding field.