### PR TITLE
Correct pt_BR entry in pluralforms.rst

### DIFF
--- a/docs/l10n/pluralforms.rst
+++ b/docs/l10n/pluralforms.rst
@@ -161,7 +161,7 @@ a correct plural form
    pms,   Piemontese,            nplurals=2; plural=(n != 1);
    ps,    Pashto,                nplurals=2; plural=(n != 1);
    pt,    Portuguese,            nplurals=2; plural=(n != 1);
-   pt_BR, Brazilian Portuguese,  nplurals=2; plural=(n > 1);
+   pt_BR, Brazilian Portuguese,  nplurals=2; plural=(n != 1);
    **R**
    rm,    Romansh,               nplurals=2; plural=(n != 1);
    ro,    Romanian,              nplurals=3; plural=(n==1 ? 0 : (n==0 || (n%100 > 0 && n%100 < 20)) ? 1 : 2);


### PR DESCRIPTION
Brazilian Portuguese (like European Portuguese and so many other languages) has a form for one item and another for any other quantity, including 0. The previous formula was using the singular form for 0.
