### PR TITLE
Add some initial text for Gettext

### DIFF
--- a/docs/guide/plurals_programmers.rst
+++ b/docs/guide/plurals_programmers.rst
@@ -112,4 +112,4 @@ features and the tag.
 Gettext
 -------
 
-FIXME unsure how this is used
+Uses different functions for each language. See the option '--keyword[=keywordspec]' from https://www.gnu.org/software/gettext/manual/html_node/xgettext-Invocation.html . Consider using the apropriate '--language=name' option too.


### PR DESCRIPTION
Gettext is rather complex to explain so i'd add a reference to the original handbook and mentoin the important points. 
Sorry for any bad spelling, i am new to writing wiki entries.