### PR TITLE
Fix typo in capitalisation.rst

### DIFF
--- a/docs/guide/translation/capitalisation.rst
+++ b/docs/guide/translation/capitalisation.rst
@@ -40,7 +40,7 @@ match these capitals as they are often done for a reason.  Sometimes they
 represent phrases that will be joined at runtime (this is a bad practice and
 should be reported to the programmer for correction).
 
-To check your staring capitals use :ref:`toolkit:pofilter` ::
+To check your starting capitals use :ref:`toolkit:pofilter` ::
 
   pofilter -t startcaps input output
 


### PR DESCRIPTION
A small thing that caught my eye!

CI fails but it's unrelated.

http://translatehouse.org/products.html also has a typo of "Oneline" -> "Online" but I don't see a place to send in a PR for that one.