### PR TITLE
Style Kashubian and Montenegro the same as others

### DIFF
--- a/docs/l10n/pluralforms.rst
+++ b/docs/l10n/pluralforms.rst
@@ -65,7 +65,7 @@ a correct plural form
    ca,    Catalan,               nplurals=2; plural=(n != 1);
    cgg,   Chiga,                 nplurals=1; plural=0;
    cs,    Czech,                 nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;
-   csb,   Kashubian,             nplurals=3; plural=(n==1) ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;
+   csb,   Kashubian,             nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);
    cy,    Welsh,                 nplurals=4; plural=(n==1) ? 0 : (n==2) ? 1 : (n != 8 && n != 11) ? 2 : 3;
    **D**
    da,    Danish,                nplurals=2; plural=(n != 1);
@@ -130,7 +130,7 @@ a correct plural form
    lv,    Latvian,               nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n != 0 ? 1 : 2);
    **M**
    mai,   Maithili,              nplurals=2; plural=(n != 1);
-   me,    Montenegro,            nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;
+   me,    Montenegro,            nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);
    mfe,   Mauritian Creole,      nplurals=2; plural=(n > 1);
    mg,    Malagasy,              nplurals=2; plural=(n > 1);
    mi,    Maori,                 nplurals=2; plural=(n > 1);


### PR DESCRIPTION
Kashubian is the same as Polish. Montenegro is the same as Russian