### PR TITLE
Changed Plural rules of Santali language

### DIFF
--- a/docs/l10n/pluralforms.rst
+++ b/docs/l10n/pluralforms.rst
@@ -170,7 +170,7 @@ a correct plural form
    rw,    Kinyarwanda,           nplurals=2; plural=(n != 1);
    **S**
    sah,   Yakut,                 nplurals=1; plural=0;
-   sat,   Santali,               nplurals=2; plural=(n != 1);
+   sat,   Santali,               nplurals=3; plural=(n==1) ? 0 : (n==2) ? 1 : 2;
    sco,   Scots,                 nplurals=2; plural=(n != 1);
    sd,    Sindhi,                nplurals=2; plural=(n != 1);
    se,    Northern Sami,         nplurals=2; plural=(n != 1);


### PR DESCRIPTION
Plural rules for the Santali language is set to more accurately (n==1) ? 0 : (n==2) ? 1 : 2

Ref: 
* https://unicode-org.github.io/cldr-staging/charts/37/supplemental/language_plural_rules.html#sat (CLDR)
* https://discourse.mozilla.org/t/string-freezes-when-clicked/84627/2 (discussion on plural rules for Santali language.)
* https://answers.launchpad.net/launchpad/+question/699939 (Launchpad discussion on using plural rules.)